### PR TITLE
Fix UNDEFINED_VARIABLE E_NOTICE

### DIFF
--- a/lib/Client/PaymentsApi.php
+++ b/lib/Client/PaymentsApi.php
@@ -185,7 +185,7 @@ class PaymentsApi
         foreach ($keys as $key) {
           $toSign .= "&$key=" . $encoded[$key];
         }
-        if ($_tempBody != null){
+        if (isset($_tempBody)){
           $json_body = json_encode($this->apiClient->getSerializer()->sanitizeForSerialization($_tempBody));
           $toSign .="&".$json_body;
         }
@@ -429,7 +429,7 @@ class PaymentsApi
         foreach ($keys as $key) {
           $toSign .= "&$key=" . $encoded[$key];
         }
-        if ($_tempBody != null){
+        if (isset($_tempBody)){
           $json_body = json_encode($this->apiClient->getSerializer()->sanitizeForSerialization($_tempBody));
           $toSign .="&".$json_body;
         }
@@ -729,7 +729,7 @@ class PaymentsApi
         foreach ($keys as $key) {
           $toSign .= "&$key=" . $encoded[$key];
         }
-        if ($_tempBody != null){
+        if (isset($_tempBody)){
           $json_body = json_encode($this->apiClient->getSerializer()->sanitizeForSerialization($_tempBody));
           $toSign .="&".$json_body;
         }
@@ -879,7 +879,7 @@ class PaymentsApi
         foreach ($keys as $key) {
           $toSign .= "&$key=" . $encoded[$key];
         }
-        if ($_tempBody != null){
+        if (isset($_tempBody)){
           $json_body = json_encode($this->apiClient->getSerializer()->sanitizeForSerialization($_tempBody));
           $toSign .="&".$json_body;
         }
@@ -1033,7 +1033,7 @@ class PaymentsApi
         foreach ($keys as $key) {
           $toSign .= "&$key=" . $encoded[$key];
         }
-        if ($_tempBody != null){
+        if (isset($_tempBody)){
           $json_body = json_encode($this->apiClient->getSerializer()->sanitizeForSerialization($_tempBody));
           $toSign .="&".$json_body;
         }


### PR DESCRIPTION
En producción falla y explota todo cuando pasa por la línea 432 de PaymentsAPI.php . No me había dado cuenta y me llamaba la atención que nadie pagara por Khipu y era porque en producción los NOTICES hacen que se detenga la ejecución. Es importante arreglarlo. 

Deberían revisar un poco mejor ese archivo. Esa varialbe $_tempBody nunca se define. No se que rol cumple. 

Saludos!